### PR TITLE
fix for issue #5, final score not updating

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
         .add_system(transition_to_game_state)
         .add_system(transition_to_main_menu_state)
         .add_system(exit_game)
-        .add_system(handle_game_over)
+        .add_system(handle_game_over.in_base_set(CoreSet::PostUpdate))
         .run();
 }
 


### PR DESCRIPTION
Possibly/probably a better way to handle it, but at least this puts the handle_game_over at the end of the frame, which then allows the AppState switch to happen and the event to still be there for the update_final_score_text event reader.